### PR TITLE
Add fill parameter to system contructor

### DIFF
--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -1,14 +1,15 @@
 #include "utils.h"
 
 
-system::system(int N) : N(N) {
+system::system(int N, bool fill) : N(N) {
     A = new float*[N];
     for (int i = 0; i < N; ++i) {
         A[i] = new float[N];
     }
     b = new float[N];
     x = new float[N];
-    fill_data();
+    if(fill)
+        fill_data();
 }
 
 system::~system() {

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -10,7 +10,7 @@ struct system {
     float *x;
     int N;
 
-    system(int N);
+    system(int N, bool fill = true);
     void print();
     ~system();
 

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -42,4 +42,4 @@ private:
     struct system **systems;
 };
 
-int simple_jacobi(struct system *sys, double tol);
+int simple_jacobi(struct system *sys, double tol = 1e-6);


### PR DESCRIPTION
Added parameter fill for system constructor so we can choose if we are going to fill the numbers in the systems or not. This should not break any usages of the constructor since the parameter has the default value true.
This is useful to me because i am using this struct when sharing data across nodes and it is not necessary to fill the data.